### PR TITLE
Fix to use importlib.resources, not __files__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'png': [cairosvg],
         'test': tests_requirements
     },
+    python_requires='>=3.7',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
This change brings support for PyOxidizer's 'in-memory' resources